### PR TITLE
change generating tool for html from pandoc to mdtogh

### DIFF
--- a/ebook/build/Makefile
+++ b/ebook/build/Makefile
@@ -6,6 +6,8 @@ SRC_DIR = ../zh/
 #CHAPTERS = ch01.md ch02.md
 TOC = --toc --toc-depth=1
 LATEX_CLASS = report
+GHUSER = 
+GHPASS = 
 
 all: book
 
@@ -31,7 +33,10 @@ $(BUILD)/epub/$(BOOKNAME).epub: $(TITLE)
 $(BUILD)/html/$(BOOKNAME).html:
 	mkdir -p $(BUILD)/html
 	cp -r ../images/ $(BUILD)/images
-	pandoc $(TOC) --standalone --to=html5 -o $@ `ls $(SRC_DIR)*.md | grep "$(SRC_DIR)[0-9]"`
+	cp TAOP.png $(BUILD)/html
+	@tmpdir=`pwd`;\
+		cd $(BUILD)/html;\
+		mdtogh --css --user=$(GHUSER) --pass=$(GHPASS) --toc --book=$$tmpdir/book.json --file_reg='^\d.+\.md$$' $$tmpdir/$(SRC_DIR);
 
 $(BUILD)/pdf/$(BOOKNAME).pdf: $(TITLE)
 	mkdir -p $(BUILD)/pdf


### PR DESCRIPTION
由于`pandoc`生成的html文件并不是特别美观,并且只生成了一个文件,感觉不是很方便.因此,前阵子我花了些时间用python编写了一个工具,用于生成html,好处有:
-    具有目录
-    每个md文件对应一个html
-    每个html文件中具有上一章,下一章, 首页链接.
-    采用`github api`, 显示效果和github是一致的.
-    有一个主页index.html,里面显示了书的基本信息以及目录
-    安装简单.工具托管在`pypi`中,直接使用`pip install mdtogh`就可以安装了.

关于工具的[内容](https://github.com/marchtea/mdtogh), pypi上的[内容](https://pypi.python.org/pypi/mdtogh/0.0.1).

我已经用这个工具生成并且放在了自己的网站上,具体效果可以[查看](http://taop.marchtea.com).
