### PR TITLE
修改了“带通配符的字符串匹配”中方法二动态规划的部分代码

### DIFF
--- a/ebook/code/c/1.3：带通配符的字符串匹配问题.c
+++ b/ebook/code/c/1.3：带通配符的字符串匹配问题.c
@@ -154,6 +154,11 @@ char* my_find(char input[], char rule[])
 		{
 			if (rule[j - 1] == '*')
 			{
+				if (j >= 2 && rule[j - 2] == '*')
+				{
+					dp[i][j] = dp[i][j - 1];
+					continue;
+				}
 				dp[i][j] = -1;
 				if (dp[i - 1][j - 1] != -1)
 				{

--- a/ebook/zh/01.03.md
+++ b/ebook/zh/01.03.md
@@ -185,6 +185,11 @@ char* my_find(char input[], char rule[])
         {
             if (rule[j - 1] == '*')
             {
+				if (j >= 2 && rule[j - 2] == '*')
+				{
+					dp[i][j] = dp[i][j - 1];
+					continue;
+				}
                 dp[i][j] = -1;
                 if (dp[i - 1][j - 1] != -1)
                 {


### PR DESCRIPTION
1.修改前对测试用例
input: abc
rule: a*b
的匹配结果有问题
修改后没问题

2.修改了 ebook/zh/01.03.md和 ebook/code/c/1.3xxx....两个文件
