### PR TITLE
Update 01.04.md

### DIFF
--- a/ebook/zh/01.04.md
+++ b/ebook/zh/01.04.md
@@ -59,8 +59,12 @@ bool IsPalindrome2(const char *s, int n)
 	second = s + n - 1 - m;
 
 	while (first >= s)
-	if (s[first--] != s[second++]) 
-		return false; // not equal, so it's not apalindrome  
+	{
+		if (*first != *second) 
+			return false; // not equal, so it's not apalindrome  
+		first--;
+		second++;
+	}
 	return true; // check over, it's a palindrome  
 }
 ```


### PR DESCRIPTION
In the previous code, due to using s[first] and s[second], the program will be crashed with the error "Array subscript is not an integer". Both of "first" and "second" are a pointer to a char.

Code in details:
1. The previous one:

    while (first >= s)
        if (s[first--] != s[second++]) 
            return false; // not equal, so it's not apalindrome  
2.After changes:

    while (first >= s)
    {
	    if(*first != *second)
		    return false;
	    first--;
	    second++;
    }